### PR TITLE
Fix alt text and heading labels

### DIFF
--- a/education.html
+++ b/education.html
@@ -55,7 +55,7 @@
     <!-- Wheaton College -->
     <div class="content-box edu-entry">
       <div class="edu-flex">
-        <img src="images/wheatonlogo.png" alt="MIT Logo" class="edu-logo" style="align-self: center;" />
+        <img src="images/wheatonlogo.png" alt="Wheaton College Logo" class="edu-logo" style="align-self: center;" />
         <div>
           <h3>Wheaton College, Norton, MA</h3>
           <p><strong>BS:</strong> Computer Science and BA Data Science | <em>May 2026</em></p>

--- a/profile.html
+++ b/profile.html
@@ -96,9 +96,6 @@
         I’m passionate about machine learning, data visualization, and open-source contributions.
         I love gaining new experience and I’m a big sports fan—especially soccer. I also enjoy collecting sneakers and exploring fashion.
       </p>
-      <p><strong></strong></p>
-      <ul>
-      </ul>
     </div>
   </div>
 </div>
@@ -107,7 +104,7 @@
     <!-- =========================
          CERTIFICATES GRID (3×3)
          ========================= -->
-    <h2 class="section-heading"></h2>
+    <h2 class="section-heading">Certificates</h2>
     <div class="certificate-grid">
       <!-- Certificate 1 -->
       <div class="certificate-item">
@@ -135,15 +132,15 @@
       </div>
       <!-- Certificate 7 -->
       <div class="certificate-item">
-        <img src="certificates/certificate7.png" alt=" " />
+        <img src="certificates/certificate7.png" alt="Certificate 7" />
       </div>
       <!-- Certificate 8 -->
       <div class="certificate-item">
-        <img src="certificates/certificate8.jpg" alt=" " />
+        <img src="certificates/certificate8.jpg" alt="Certificate 8" />
       </div>
       <!-- Certificate 9 -->
       <div class="certificate-item">
-        <img src="certificates/certificate9.jpg" alt=" " />
+        <img src="certificates/certificate9.jpg" alt="Certificate 9" />
       </div>
     </div>
 
@@ -151,7 +148,7 @@
      SKILLS SECTION
      ========================= -->
 <div class="content-box">
-  <h2 class="section-heading"></h2>
+  <h2 class="section-heading">Skills</h2>
   <p class="about-text">
     <strong>SKILLS:</strong> Python, SQL, R Studio, VS Code, Java, C++, Mathematica, Tableau, MongoDB, Microsoft 365, Google Workspace, GitHub
   </p>


### PR DESCRIPTION
## Summary
- correct alt text for the Wheaton College logo
- add missing section headings and alt text for certificates
- clean up unused markup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853650fcaa08332afc93139cb75c0eb