### PR TITLE
Update modal image alt handling

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -190,6 +190,7 @@
       img.addEventListener('click', () => {
         modal.style.display = 'flex';
         modalImg.src = img.src;
+        modalImg.alt = img.alt;
         captionText.textContent = img.alt;
       });
     });


### PR DESCRIPTION
## Summary
- keep modal `<img>` alt attribute empty in profile page
- assign `modalImg.alt` when thumbnail clicked so lightbox is accessible

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853690d2b7483329c785700ba54b88a