### PR TITLE
Add meta descriptions and OG tags

### DIFF
--- a/education.html
+++ b/education.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Education background of Tushar Koushik." />
+  <meta property="og:title" content="Education • Tushar Koushik" />
+  <meta
+    property="og:description"
+    content="Education background of Tushar Koushik."
+  />
+  <meta property="og:image" content="headshot.jpg" />
   <title>Education • Tushar Koushik</title>
 
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&display=swap" rel="stylesheet" />

--- a/experience.html
+++ b/experience.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Professional experience of Tushar Koushik." />
+  <meta property="og:title" content="Experience • Tushar Koushik" />
+  <meta
+    property="og:description"
+    content="Professional experience of Tushar Koushik."
+  />
+  <meta property="og:image" content="headshot.jpg" />
   <title>Experience • Tushar Koushik</title>
 
   <!-- Monospaced font (Fira Code) -->

--- a/extracurricular.html
+++ b/extracurricular.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Extracurricular activities of Tushar Koushik." />
+  <meta property="og:title" content="Extracurricular • Tushar Koushik" />
+  <meta
+    property="og:description"
+    content="Extracurricular activities of Tushar Koushik."
+  />
+  <meta property="og:image" content="headshot.jpg" />
   <title>Extracurricular • Tushar Koushik</title>
 
   <!-- Monospaced font (Fira Code) -->

--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="News feed and updates from Tushar Koushik." />
+  <meta property="og:title" content="Feed • Tushar Koushik" />
+  <meta
+    property="og:description"
+    content="News feed and updates from Tushar Koushik."
+  />
+  <meta property="og:image" content="headshot.jpg" />
   <title>Feed • Tushar Koushik</title>
 
   <!-- Monospaced font (Fira Code) -->

--- a/post-portfolio.html
+++ b/post-portfolio.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Announcement of Tushar Koushik's portfolio website launch." />
+  <meta property="og:title" content="Portfolio Website Launch • Tushar Koushik" />
+  <meta
+    property="og:description"
+    content="Announcement of Tushar Koushik's portfolio website launch."
+  />
+  <meta property="og:image" content="headshot.jpg" />
   <title>Portfolio Website Launch • Tushar Koushik</title>
 
   <!-- Monospaced font -->

--- a/profile.html
+++ b/profile.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Profile of Tushar Koushik including interests and contact information." />
+  <meta property="og:title" content="Profile • Tushar Koushik" />
+  <meta
+    property="og:description"
+    content="Profile of Tushar Koushik including interests and contact information."
+  />
+  <meta property="og:image" content="headshot.jpg" />
   <title>Profile • Tushar Koushik</title>
 
   <!-- Monospaced font (Fira Code) -->


### PR DESCRIPTION
## Summary
- add page descriptions across all html pages
- include Open Graph metadata for better social sharing

## Testing
- `npm test` *(fails: could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685368ff205c833284e2a1a963aebd64